### PR TITLE
Add new settings in provider config

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,8 @@ terraform {
 }
 
 provider "appclacks" {
+  organization_id = ""
+  token = ""
 }
 
 resource "appclacks_healthcheck_command" "test_command" {
@@ -101,3 +103,5 @@ resource "appclacks_healthcheck_tcp" "test_tcp" {
 ### Optional
 
 - `api_url` (String)
+- `organization_id` (String, Sensitive) The organization ID to use for the Appclacks API
+- `token` (String, Sensitive) The token to use for the Appclacks API

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -8,6 +8,8 @@ terraform {
 }
 
 provider "appclacks" {
+  organization_id = ""
+  token = ""
 }
 
 resource "appclacks_healthcheck_command" "test_command" {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/appclacks/terraform-provider-appclacks
 go 1.19
 
 require (
-	github.com/appclacks/cli v0.4.1-0.20221230220150-4299738cce9f
+	github.com/appclacks/cli v0.5.0
 	github.com/appclacks/go-types v0.0.0-20221217093431-7bdb84d911b4
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-docs v0.13.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/appclacks/terraform-provider-appclacks
 go 1.19
 
 require (
-	github.com/appclacks/cli v0.4.1-0.20221223181017-804f80bce958
+	github.com/appclacks/cli v0.4.1-0.20221230220150-4299738cce9f
 	github.com/appclacks/go-types v0.0.0-20221217093431-7bdb84d911b4
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
@@ -18,6 +18,7 @@ require (
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect
+	github.com/cheynewallace/tabby v1.1.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
@@ -43,6 +44,7 @@ require (
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mitchellh/cli v1.1.4 // indirect
@@ -56,6 +58,8 @@ require (
 	github.com/russross/blackfriday v1.6.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
+	github.com/spf13/cobra v1.5.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v4 v4.3.12 // indirect
 	github.com/vmihailenco/tagparser v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/appclacks/cli v0.4.1-0.20221223181017-804f80bce958 h1:KDrXjarzWh9Amaw
 github.com/appclacks/cli v0.4.1-0.20221223181017-804f80bce958/go.mod h1:UCZn3xXwpl15tmTFZR6RaQ+9Xc8VUt+EarXKr60pC9o=
 github.com/appclacks/cli v0.4.1-0.20221230220150-4299738cce9f h1:ZB75AFnlST9IYU/nel9xMtkmM82fMhCfTIOIqm402AY=
 github.com/appclacks/cli v0.4.1-0.20221230220150-4299738cce9f/go.mod h1:UCZn3xXwpl15tmTFZR6RaQ+9Xc8VUt+EarXKr60pC9o=
+github.com/appclacks/cli v0.5.0 h1:GZ382cMj3w0QkBxZTcQMvLR0UcWU/A84sgSJXRO1Vms=
+github.com/appclacks/cli v0.5.0/go.mod h1:UCZn3xXwpl15tmTFZR6RaQ+9Xc8VUt+EarXKr60pC9o=
 github.com/appclacks/go-types v0.0.0-20221217093431-7bdb84d911b4 h1:7rPxIJKs6tOzHGjNCMA1MvWXVpFAq3i8QIIuw/5bDak=
 github.com/appclacks/go-types v0.0.0-20221217093431-7bdb84d911b4/go.mod h1:ULkbKlyVigBCY+eSEV0scorq+akwJlVbdnLI5xI8IwU=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,12 @@ github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
+github.com/appclacks/cli v0.4.0 h1:/3U6/kfojw65VCRK+5fz8/eEPH75whDxDUbviuqMQiY=
+github.com/appclacks/cli v0.4.0/go.mod h1:UCZn3xXwpl15tmTFZR6RaQ+9Xc8VUt+EarXKr60pC9o=
 github.com/appclacks/cli v0.4.1-0.20221223181017-804f80bce958 h1:KDrXjarzWh9AmawrQHXfw7XaX6O1HazBAtHm1MVH69M=
 github.com/appclacks/cli v0.4.1-0.20221223181017-804f80bce958/go.mod h1:UCZn3xXwpl15tmTFZR6RaQ+9Xc8VUt+EarXKr60pC9o=
+github.com/appclacks/cli v0.4.1-0.20221230220150-4299738cce9f h1:ZB75AFnlST9IYU/nel9xMtkmM82fMhCfTIOIqm402AY=
+github.com/appclacks/cli v0.4.1-0.20221230220150-4299738cce9f/go.mod h1:UCZn3xXwpl15tmTFZR6RaQ+9Xc8VUt+EarXKr60pC9o=
 github.com/appclacks/go-types v0.0.0-20221217093431-7bdb84d911b4 h1:7rPxIJKs6tOzHGjNCMA1MvWXVpFAq3i8QIIuw/5bDak=
 github.com/appclacks/go-types v0.0.0-20221217093431-7bdb84d911b4/go.mod h1:ULkbKlyVigBCY+eSEV0scorq+akwJlVbdnLI5xI8IwU=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
@@ -35,7 +39,10 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkY
 github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/cheynewallace/tabby v1.1.1 h1:JvUR8waht4Y0S3JF17G6Vhyt+FRhnqVCkk8l4YrOU54=
+github.com/cheynewallace/tabby v1.1.1/go.mod h1:Pba/6cUL8uYqvOc9RkyvFbHGrQ9wShyrn6/S/1OYVys=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -143,6 +150,8 @@ github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.13 h1:lFzP57bqS/wsqKssCGmtLAb8A0wKjLGrve2q3PPVcBk=
 github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK2O4oXg=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
+github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
@@ -199,6 +208,7 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
 github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=
 github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNlmVHqNRXXJNAY=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sebdah/goldie v1.0.0/go.mod h1:jXP4hmWywNEwZzhMuv2ccnqTSFpuq8iyQhtQdkkZBH4=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
@@ -209,6 +219,10 @@ github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMB
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cast v1.5.0 h1:rj3WzYc11XZaIZMPKmwP96zkFEnnAmV8s6XbB2aY32w=
 github.com/spf13/cast v1.5.0/go.mod h1:SpXXQ5YoyJw6s3/6cMTQuxvgRl3PCJiyaX9p6b155UU=
+github.com/spf13/cobra v1.5.0 h1:X+jTBEBqF0bHN+9cSMgmfuvv2VHJ9ezmFNf9Y/XstYU=
+github.com/spf13/cobra v1.5.0/go.mod h1:dWXEIy2H428czQCjInthrTRUg7yKbok+2Qi/yBIJoUM=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
@@ -338,6 +352,7 @@ gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRN
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,8 @@ terraform {
 }
 
 provider "appclacks" {
+  organization_id = ""
+  token = ""
 }
 
 resource "appclacks_healthcheck_command" "test_command" {

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -26,6 +26,20 @@ func Provider() *schema.Provider {
 				Optional: true,
 				Default:  defaultAPIURL,
 			},
+			"organization_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Sensitive:   true,
+				DefaultFunc: schema.EnvDefaultFunc("APPCLACKS_ORGANIZATION_ID", ""),
+				Description: "The organization ID to use for the Appclacks API",
+			},
+			"token": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Sensitive:   true,
+				DefaultFunc: schema.EnvDefaultFunc("APPCLACKS_TOKEN", ""),
+				Description: "The token to use for the Appclacks API",
+			},
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{},
@@ -42,14 +56,15 @@ func Provider() *schema.Provider {
 
 // providerConfigure parses the config into the Terraform provider meta object
 func providerConfigure(_ context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
-	apiURL := d.Get("api_url").(string)
-	if apiURL == "" {
-		apiURL = defaultAPIURL
-	}
 
-	client := client.New(apiURL)
+	return client.New(
+		d.Get("api_url").(string),
+		client.WithToken(
+			client.OrganizationID(d.Get("organization_id").(string)),
+			client.Token(d.Get("token").(string)),
+		),
+	), nil
 
-	return client, nil
 }
 
 func GetAppclacksClient(meta interface{}) *client.Client {


### PR DESCRIPTION
Related to the PR on CLI([#1](https://github.com/appclacks/cli/pull/1)) added the possibility to configure the terraform provider with the organizationID and the Token directly in the terraform configuration files.

Docs and examples is updated. 

Result of tests : 
```
TF_ACC=1 go test -v -race ./...
?       github.com/appclacks/terraform-provider-appclacks       [no test files]
=== RUN   TestAccResourceHealthcheckCommand
--- PASS: TestAccResourceHealthcheckCommand (2.55s)
=== RUN   TestAccResourceHealthcheckDNS
--- PASS: TestAccResourceHealthcheckDNS (2.37s)
=== RUN   TestAccResourceHealthcheckHTTP
--- PASS: TestAccResourceHealthcheckHTTP (2.38s)
=== RUN   TestAccResourceHealthcheckTCP
--- PASS: TestAccResourceHealthcheckTCP (2.27s)
=== RUN   TestAccResourceHealthcheckTLS
--- PASS: TestAccResourceHealthcheckTLS (2.48s)
PASS
ok      github.com/appclacks/terraform-provider-appclacks/provider      12.550s
```